### PR TITLE
Fix issue with single quotes in directory names

### DIFF
--- a/lib/fixi/index.rb
+++ b/lib/fixi/index.rb
@@ -82,9 +82,9 @@ class Fixi::Index
     if path && File.expand_path(path) != @rootpath
       relpath = relpath(File.expand_path(path))
       if File.directory?(path)
-        conditions << " relpath like '#{relpath}/%'"
+        conditions << " relpath like ?"
       else
-        conditions << " relpath = '#{relpath}'"
+        conditions << " relpath = ?"
       end
     end
     attribs.each do |name,value|
@@ -103,8 +103,20 @@ class Fixi::Index
         sql += " #{c}"
       end
     end
-    @db.execute(sql) do |hash|
-      yield hash
+    if (!relpath.nil?) 
+      if File.directory?(path)
+        @db.execute(sql, relpath+"/%") do |hash|
+          yield hash
+        end
+      else
+        @db.execute(sql, relpath) do |hash|
+          yield hash
+        end
+      end
+    else
+      @db.execute(sql) do |hash|
+        yield hash
+      end
     end
   end
 


### PR DESCRIPTION
Steps to recreate the issue: 

```
mkdir fixitest
cd fixitest && fixi init 
mkdir john\'s\ files 
touch john\'s\ files/foo
fixi add 
```

then 

```
fixi ls john\'s\ files
```

or 

```
cd john\'s\ files
fixi ls . 
```

results in 

```
/root/.rvm/gems/ruby-2.3.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `initialize': near "s": syntax error (SQLite3::SQLException)
        from /root/.rvm/gems/ruby-2.3.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `new'
        from /root/.rvm/gems/ruby-2.3.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:91:in `prepare'
        from /root/.rvm/gems/ruby-2.3.0/gems/sqlite3-1.3.11/lib/sqlite3/database.rb:134:in `execute'
        from /root/.rvm/gems/ruby-2.3.0/gems/fixi-0.1.0/lib/fixi/index.rb:106:in `each'
        from /root/.rvm/gems/ruby-2.3.0/gems/fixi-0.1.0/lib/fixi/command/ls.rb:41:in `execute'
```

The issue also affects `fixi {rm, check, commit}` if the same syntax is used. 
i.e. by specifying `fixi rm .`  from inside the directory `john's files/` 
or `fixi rm "john's files"/` from the parent directory. 
