### PR TITLE
Allow 'ls' and 'rm' for file, even if it doesn't exist in file system

### DIFF
--- a/lib/fixi/command/ls.rb
+++ b/lib/fixi/command/ls.rb
@@ -33,7 +33,7 @@ class Fixi::Command::Ls
       opt :verbose, "Include all information known about each file. By default,
         only paths will be listed.".pack
     end
-    index = Fixi::Index.new(args[0])
+    index = Fixi::Index.new(args[0], false, nil, false)
     if opts[:json]
       print "["
     end

--- a/lib/fixi/command/rm.rb
+++ b/lib/fixi/command/rm.rb
@@ -23,7 +23,7 @@ class Fixi::Command::Rm
       opt :dry_run, "Don't do anything; just report what would be done"
     end
     path = File.expand_path(args[0] || ".")
-    index = Fixi::Index.new(path)
+    index = Fixi::Index.new(path, false, nil, false)
 
     index.each(args[0]) do |hash|
       relpath = hash['relpath']


### PR DESCRIPTION
Fixes issue #3.

It is sometimes necessary to list or remove files that have an entry in
the index (fixity database), but which do not exist (any longer) in the
file system. Prior to this commit, a dummy file must be created at the
desired path to enable these operations. This is not even possible when
that part of the file system is not writable. And when it is, this
creates a risk of leaving the dummy file behind or clobbering another file.